### PR TITLE
chore: add variance to tests to account for event loop fluctuations

### DIFF
--- a/test/unit/measureTimeTests.ts
+++ b/test/unit/measureTimeTests.ts
@@ -2,8 +2,11 @@ import { assert } from 'assertthat';
 import { measureTime } from '../../lib/measureTime';
 import { setTimeout as wait } from 'timers/promises';
 
-suite('measureTime', (): void => {
-  const epsilon = 50;
+suite('measureTime', function (): void {
+  const expectedStdError = 5;
+  const expectedVariance = expectedStdError ** 2;
+
+  this.timeout(3_000);
 
   test('is a function.', async (): Promise<void> => {
     assert.that(measureTime).is.ofType('function');
@@ -15,44 +18,43 @@ suite('measureTime', (): void => {
 
   test('measures short time ranges.', async (): Promise<void> => {
     const timeoutMs = 100;
-    const getElapsed = measureTime();
+    const measure = measureTime();
 
     await wait(timeoutMs);
 
-    const elapsed = getElapsed();
+    const measured = measure();
+    const error = measured.millisecondsTotal - timeoutMs;
+    const variance = error ** 2;
 
-    assert.that(elapsed.seconds).is.equalTo(0);
-    assert.that(elapsed.milliseconds).is.atLeast(timeoutMs);
-    assert.that(elapsed.milliseconds).is.lessThan(timeoutMs + epsilon);
+    assert.that(variance).is.lessThan(expectedVariance);
   });
 
   test('measures longer time ranges.', async (): Promise<void> => {
-    const timeoutMs = 500;
-    const getElapsed = measureTime();
+    const timeoutMs = 1_780;
+    const measure = measureTime();
 
     await wait(timeoutMs);
 
-    const elapsed = getElapsed();
+    const measured = measure();
+    const error = measured.millisecondsTotal - timeoutMs;
+    const variance = error ** 2;
 
-    assert.that(elapsed.seconds).is.equalTo(0);
-    assert.that(elapsed.milliseconds).is.atLeast(timeoutMs);
-    assert.that(elapsed.milliseconds).is.lessThan(timeoutMs + epsilon);
-    assert.that(elapsed.millisecondsTotal).is.atLeast(timeoutMs);
-    assert.that(elapsed.millisecondsTotal).is.lessThan(timeoutMs + epsilon);
+    assert.that(variance).is.lessThan(expectedVariance);
   });
 
   test('calculates the total milliseconds.', async (): Promise<void> => {
     const timeoutMs = 1_500;
-    const getElapsed = measureTime();
+    const measure = measureTime();
 
     await wait(timeoutMs);
 
-    const elapsed = getElapsed();
+    const measured = measure();
+    const error = measured.millisecondsTotal - timeoutMs;
+    const variance = error ** 2;
 
-    assert.that(elapsed.seconds).is.equalTo(1);
-    assert.that(elapsed.milliseconds).is.atLeast(500);
-    assert.that(elapsed.milliseconds).is.lessThan(500 + epsilon);
-    assert.that(elapsed.millisecondsTotal).is.atLeast(timeoutMs);
-    assert.that(elapsed.millisecondsTotal).is.lessThan(timeoutMs + epsilon);
+    assert.that(measured.seconds).is.equalTo(1);
+    assert.that(measured.milliseconds).is.atLeast(500 - expectedStdError);
+    assert.that(measured.milliseconds).is.lessThan(500 + expectedStdError);
+    assert.that(variance).is.lessThan(expectedVariance);
   });
 });


### PR DESCRIPTION
Since we can't precisely control scheduling in Node.js (or at least not __more precisely__ than `process.hrtime` can measure), it is difficult to test this module correctly. Without external verification, it can't be fully tested regarding accuracy of the clock provided. We test in Node.js, so we have to work with these constraints.

In practice, an execution scheduled by `setTimeout` can be:
1. Executed exactly at the specified timeout when the event loop is not busy.
2. Delayed on the order of 1e2 ms when the event loop is busy.
3. Executed __just before__ the specified timeout, this is usually on the order of a single millisecond.

We had accounted for the delay case, but not for premature execution. To fix this, this PR changes the tests to use the quadratic error of the measurement regarding the specified timeout. Instead of asserting the measured times, the error is asserted to be below a certain value.