### PR TITLE
chore: calibrate tests against process.hrtime

### DIFF
--- a/test/unit/measureTimeTests.ts
+++ b/test/unit/measureTimeTests.ts
@@ -15,12 +15,13 @@ suite('measureTime', function (): void {
 
     for (let i = 0; i < calibrationSamplesCount; i++) {
       const timeoutMs = Math.random() * 100;
-      const measure = measureTime();
+      const start = process.hrtime.bigint();
 
       await wait(timeoutMs);
 
-      const measured = measure();
-      const variance = (timeoutMs - measured.millisecondsTotal) ** 2;
+      const end = process.hrtime.bigint();
+      const measuredMs = Number((end - start) / BigInt(1e6));
+      const variance = (timeoutMs - measuredMs) ** 2;
 
       calibrationVarianceSum += variance;
     }
@@ -28,11 +29,11 @@ suite('measureTime', function (): void {
     const calibrationVariance = calibrationVarianceSum / calibrationSamplesCount;
     const calibrationStdError = Math.sqrt(calibrationVariance);
 
-    expectedStdError = 3 * calibrationStdError;
+    expectedStdError = 5 * calibrationStdError;
     expectedVariance = expectedStdError ** 2;
 
     // eslint-disable-next-line no-console
-    console.log(`Calibrated tests to sigma: ${expectedStdError}.`);
+    console.log(`Calibrated tests to sigma: ${calibrationStdError} ms. Using 5 sigma interval (+/- ${expectedStdError} ms)`);
   });
 
   test('is a function.', async (): Promise<void> => {

--- a/test/unit/measureTimeTests.ts
+++ b/test/unit/measureTimeTests.ts
@@ -2,8 +2,11 @@ import { assert } from 'assertthat';
 import { measureTime } from '../../lib/measureTime';
 import { setTimeout as wait } from 'timers/promises';
 
-suite('measureTime', (): void => {
-  const epsilon = 50;
+suite('measureTime', function (): void {
+  const expectedStdError = 5;
+  const expectedVariance = expectedStdError ** 2;
+
+  this.timeout(3_000);
 
   test('is a function.', async (): Promise<void> => {
     assert.that(measureTime).is.ofType('function');
@@ -15,44 +18,43 @@ suite('measureTime', (): void => {
 
   test('measures short time ranges.', async (): Promise<void> => {
     const timeoutMs = 100;
-    const getElapsed = measureTime();
+    const measure = measureTime();
 
     await wait(timeoutMs);
 
-    const elapsed = getElapsed();
+    const measured = measure();
+    const error = measured.millisecondsTotal - timeoutMs;
+    const variance = error ** 2;
 
-    assert.that(elapsed.seconds).is.equalTo(0);
-    assert.that(elapsed.milliseconds).is.atLeast(timeoutMs);
-    assert.that(elapsed.milliseconds).is.lessThan(timeoutMs + epsilon);
+    assert.that(variance).is.lessThan(expectedVariance);
   });
 
   test('measures longer time ranges.', async (): Promise<void> => {
-    const timeoutMs = 500;
-    const getElapsed = measureTime();
+    const timeoutMs = 1_780;
+    const measure = measureTime();
 
     await wait(timeoutMs);
 
-    const elapsed = getElapsed();
+    const measured = measure();
+    const error = measured.millisecondsTotal - timeoutMs;
+    const variance = error ** 2;
 
-    assert.that(elapsed.seconds).is.equalTo(0);
-    assert.that(elapsed.milliseconds).is.atLeast(timeoutMs);
-    assert.that(elapsed.milliseconds).is.lessThan(timeoutMs + epsilon);
-    assert.that(elapsed.millisecondsTotal).is.atLeast(timeoutMs);
-    assert.that(elapsed.millisecondsTotal).is.lessThan(timeoutMs + epsilon);
+    assert.that(variance).is.lessThan(expectedVariance);
   });
 
   test('calculates the total milliseconds.', async (): Promise<void> => {
     const timeoutMs = 1_500;
-    const getElapsed = measureTime();
+    const measure = measureTime();
 
     await wait(timeoutMs);
 
-    const elapsed = getElapsed();
+    const measured = measure();
+    const error = measured.millisecondsTotal - timeoutMs;
+    const variance = error ** 2;
 
-    assert.that(elapsed.seconds).is.equalTo(1);
-    assert.that(elapsed.milliseconds).is.atLeast(500);
-    assert.that(elapsed.milliseconds).is.lessThan(500 + epsilon);
-    assert.that(elapsed.millisecondsTotal).is.atLeast(timeoutMs);
-    assert.that(elapsed.millisecondsTotal).is.lessThan(timeoutMs + epsilon);
+    assert.that(measured.seconds).is.equalTo(1);
+    assert.that(measured.milliseconds).is.atLeast(500 - expectedStdError);
+    assert.that(measured.milliseconds).is.lessThan(500 + expectedStdError);
+    assert.that(variance).is.lessThan(expectedVariance);
   });
 });


### PR DESCRIPTION
Previously, we were calibrating the tests using the library itself, which masks certain kinds of errors.
This PR changes the tests to use `process.hrtime` as its source of truth. The confidence interval is also widened to 5 sigma.